### PR TITLE
Support embedded Tomcat

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,19 @@
 		</repository>
 	</repositories>
 
+	<pluginRepositories>
+		<pluginRepository>
+			<id>evolveum</id>
+			<name>Evolveum Public Releases</name>
+			<url>http://nexus.evolveum.com/nexus/content/groups/public</url>
+		</pluginRepository>
+		<pluginRepository>
+			<id>evolveum-snapshots</id>
+			<name>Evolveum Snapshots</name>
+			<url>http://nexus.evolveum.com/nexus/content/repositories/snapshots/</url>
+		</pluginRepository>
+	</pluginRepositories>
+
 	<properties>
 		<project.source.version>1.8</project.source.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -116,6 +129,13 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 				<version>${spring.boot.version}</version>
+				<dependencies>
+					<dependency>
+						<groupId>com.evolveum.midpoint</groupId>
+						<artifactId>midpoint-war-layout</artifactId>
+						<version>3.9-SNAPSHOT</version>
+					</dependency>
+				</dependencies>
 				<executions>
 					<execution>
 						<goals>


### PR DESCRIPTION
Currently, the generated war doesn't support embedded Tomcat because the `MANIFEST.MF` file is created with spring's `Main-Class` as below. MidPoint requires [own main-class](https://github.com/Evolveum/midpoint/blob/d851d34b76c840c60cb5c93c8931055ef3039048/tools/midpoint-war-layout/src/main/java/com/evolveum/midpoint/tools/layout/MidPointWarLauncher.java) for supporting embedded Tomcat.

```
Manifest-Version: 1.0
Archiver-Version: Plexus Archiver
Built-By: h2-wada
Start-Class: com.evolveum.midpoint.web.boot.MidPointSpringApplication
Spring-Boot-Classes: WEB-INF/classes/
Spring-Boot-Lib: WEB-INF/lib/
Spring-Boot-Version: 1.5.7.RELEASE
Created-By: Apache Maven 3.5.4
Build-Jdk: 1.8.0_171
Main-Class: org.springframework.boot.loader.WarLauncher
```

To change the main-class, I added one dependency for `midpoint-war-layout` in the plugin which 
 is for changing the main-class.